### PR TITLE
Open a new tab test

### DIFF
--- a/tests/playground/ui/fixtures/playground-pages.ts
+++ b/tests/playground/ui/fixtures/playground-pages.ts
@@ -4,6 +4,8 @@ import { test as baseTest } from '@playwright/test';
 import { VerifyAccountPage } from '../pages/verify-account-page';
 import { TagsInputBoxPage } from '../pages/tags-input-box-page';
 import { ShadowDomPage } from '../pages/shadow-dom-page';
+import { NewTabPage } from '../pages/new-tab-page';
+import { NewPagePage } from '../pages/new-page-page';
 
 type PlaygroundPages = {
     verifyAccountPage: VerifyAccountPage;
@@ -11,6 +13,8 @@ type PlaygroundPages = {
     mouseHoverPage: MouseHoverPage;
     tagsInputBoxPage: TagsInputBoxPage;
     shadowDomPage: ShadowDomPage;
+    newTabPage: NewTabPage;
+    newPagePage: NewPagePage
 }
 
 export const test = baseTest.extend<PlaygroundPages>({
@@ -29,6 +33,9 @@ export const test = baseTest.extend<PlaygroundPages>({
     shadowDomPage: async ({ page }, use) => {
         await use(new ShadowDomPage(page));
     },
+    newTabPage: async ({ page }, use) => {
+        await use(new NewTabPage(page));
+    }
 });
 
 export { expect } from '@playwright/test';

--- a/tests/playground/ui/new-tab.spec.ts
+++ b/tests/playground/ui/new-tab.spec.ts
@@ -11,7 +11,7 @@ test.describe('New Tab', () => {
         // Prepare the wait event for the new tab. With this line, you are telling Playwright that this event will occur.
         const newTabPromise = newTabPage.page.waitForEvent('popup');
         await newTabPage.openNewTab();
-        // In this case, NewPagePage needs to receive a Promise<Page> because the page is being created from an event
+        // In this case, NewPagePage needs to receive a Promise<Page> because [Romina dont approve this comment] the page is being created from an event
         const newPagePage: NewPagePage = new NewPagePage(await newTabPromise);
         await expect(await newPagePage.getWelcomeMessage()).toBeVisible();
         await expect(await newPagePage.getUrl()).toBe('https://qaplayground.dev/apps/new-tab/new-page')

--- a/tests/playground/ui/new-tab.spec.ts
+++ b/tests/playground/ui/new-tab.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from './fixtures/playground-pages';
+import { NewPagePage } from './pages/new-page-page';
+
+test.describe('New Tab', () => {
+
+    test.beforeEach(async ({ newTabPage }) => {
+        await newTabPage.goto();
+     });
+
+     test("Should open a new tab succesfull", async ({ newTabPage}) => {
+        // Prepare the wait event for the new tab. With this line, you are telling Playwright that this event will occur.
+        const newTabPromise = newTabPage.page.waitForEvent('popup');
+        await newTabPage.openNewTab();
+        // In this case, NewPagePage needs to receive a Promise<Page> because the page is being created from an event
+        const newPagePage: NewPagePage = new NewPagePage(await newTabPromise);
+        await expect(await newPagePage.getWelcomeMessage()).toBeVisible();
+        await expect(await newPagePage.getUrl()).toBe('https://qaplayground.dev/apps/new-tab/new-page')
+        await expect(await newPagePage.getTitle()).toBe('New Page');
+     });
+});

--- a/tests/playground/ui/pages/new-page-page.ts
+++ b/tests/playground/ui/pages/new-page-page.ts
@@ -1,0 +1,23 @@
+import { Locator, Page } from '@playwright/test';
+
+export class NewPagePage  {
+  readonly page : Page
+  readonly welcomeMessage: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.welcomeMessage = page.getByRole('heading', { name: 'Welcome to the new page!' });
+  }
+
+  async getWelcomeMessage(): Promise<Locator> {
+    return await this.welcomeMessage;
+  }
+
+  async getTitle(): Promise<string>{
+    return await this.page.title();
+  }
+
+  async getUrl(): Promise<string>{
+    return await this.page.url();
+  }
+}

--- a/tests/playground/ui/pages/new-tab-page.ts
+++ b/tests/playground/ui/pages/new-tab-page.ts
@@ -1,0 +1,19 @@
+import { Locator, Page } from '@playwright/test';
+
+export class NewTabPage  {
+  readonly page : Page
+  readonly openNewTabButton: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.openNewTabButton = page.getByRole('link', { name: 'Open New Tab' });
+  }
+
+  async goto() {
+    await this.page.goto('/apps/new-tab/');
+  }
+
+  async openNewTab() {
+    await this.openNewTabButton.click();
+  }
+}

--- a/tests/playground/ui/verify-account.spec.ts
+++ b/tests/playground/ui/verify-account.spec.ts
@@ -1,4 +1,3 @@
-import { VerifyAccountPage } from './pages/verify-account-page';
 import { test, expect } from './fixtures/playground-pages';
 test.describe('Verify Account', () => {
     test.beforeEach(async ({ verifyAccountPage }) => {


### PR DESCRIPTION
Resolves #6 
- Add new Tab Test
- Create two Page Object Model (POM) classes: one for the start page and another for the new page that is opened by a click.

![image](https://github.com/user-attachments/assets/f973be09-732e-40dc-a879-fe5cae12556e)
