### PR TITLE
Add Redirect chain test

### DIFF
--- a/tests/playground/ui/fixtures/playground-pages.ts
+++ b/tests/playground/ui/fixtures/playground-pages.ts
@@ -5,6 +5,7 @@ import { VerifyAccountPage } from '../pages/verify-account-page';
 import { TagsInputBoxPage } from '../pages/tags-input-box-page';
 import { ShadowDomPage } from '../pages/shadow-dom-page';
 import { UploadFilePage } from '../pages/upload-file-page';
+import { RedirectChainPage } from '../pages/redirect-chain-page';
 
 type PlaygroundPages = {
     verifyAccountPage: VerifyAccountPage;
@@ -13,6 +14,7 @@ type PlaygroundPages = {
     tagsInputBoxPage: TagsInputBoxPage;
     shadowDomPage: ShadowDomPage;
     uploadFilePage: UploadFilePage;
+    redirectChainPage: RedirectChainPage;
 }
 
 export const test = baseTest.extend<PlaygroundPages>({
@@ -34,6 +36,9 @@ export const test = baseTest.extend<PlaygroundPages>({
     uploadFilePage: async ({ page }, use) => {
         await use(new UploadFilePage(page));
     },
+    redirectChainPage: async ({ page }, use) => {
+        await use(new RedirectChainPage(page));
+    }
 });
 
 export { expect } from '@playwright/test';

--- a/tests/playground/ui/pages/redirect-chain-page.ts
+++ b/tests/playground/ui/pages/redirect-chain-page.ts
@@ -1,0 +1,41 @@
+import { Locator, Page } from '@playwright/test';
+
+export class RedirectChainPage {
+  readonly page: Page
+  readonly buttonStartRedirection: Locator;
+  readonly infoOfPage: Locator;
+  readonly buttonBack: Locator;
+  constructor(page: Page) {
+    this.page = page;
+    this.buttonStartRedirection = page.getByRole('link', { name: 'Start Redirection chain' });
+    this.infoOfPage = page.locator('#info');
+    this.buttonBack = page.getByRole('link', { name: 'Go Back' });
+  }
+
+  async goto() {
+    return await this.page.goto('/apps/redirect');
+  }
+
+  async clickButtonStartRedirection() {
+    await this.buttonStartRedirection.click();
+  }
+  async clickButtonBack() {
+    await this.buttonBack.click();
+  }
+
+  async getInfoOfPage() {
+    return await this.infoOfPage.textContent();
+  }
+
+  async getUrl() {
+    return await this.page.url();
+  }
+
+  async waitForURL() {
+    return await this.page.waitForURL('**/pagina-final', { timeout: 10000 });
+  }
+
+  async getTitle() {
+    return await this.page.title();
+  }
+}

--- a/tests/playground/ui/redirect-chain.spec.ts
+++ b/tests/playground/ui/redirect-chain.spec.ts
@@ -32,15 +32,16 @@ test.describe('Redirect chain', () => {
         await redirectChainPage.page.waitForURL('**/apps/redirect/last', { timeout: 10000 });
 
         expect(await redirectChainPage.getTitle()).toContain('Last Page');
-        expect(await redirectChainPage.getUrl()).toContain("/apps/redirect/last");
+        expect(await redirectChainPage.getUrl()).toContain(`${process.env.BASE_URL}apps/redirect/last`);
         expect(await redirectChainPage.getInfoOfPage()).toContain("Welcome to the Last Page");
         expect(redirectChain.length).toBe(6);
-        expect(redirectChain[0]).toContain("/apps/redirect/second");
-        expect(redirectChain[1]).toContain("/apps/redirect/third");
-        expect(redirectChain[2]).toContain("/apps/redirect/fourth");
-        expect(redirectChain[3]).toContain("/apps/redirect/fifth");
-        expect(redirectChain[4]).toContain("/apps/redirect/sixth");
-        expect(redirectChain[5]).toContain("/apps/redirect/last");
+        expect(redirectChain[0]).toEqual(`${process.env.BASE_URL}apps/redirect/second.html`);
+        expect(redirectChain[1]).toEqual(`${process.env.BASE_URL}apps/redirect/third.html`);
+        expect(redirectChain[2]).toEqual(`${process.env.BASE_URL}apps/redirect/fourth.html`);
+        expect(redirectChain[3]).toEqual(`${process.env.BASE_URL}apps/redirect/fifth.html`);
+        expect(redirectChain[4]).toEqual(`${process.env.BASE_URL}apps/redirect/sixth.html`);
+        expect(redirectChain[5]).toEqual(`${process.env.BASE_URL}apps/redirect/last.html`);
+
     });
 
     test.afterEach(async ({ redirectChainPage }) => {

--- a/tests/playground/ui/redirect-chain.spec.ts
+++ b/tests/playground/ui/redirect-chain.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from './fixtures/playground-pages';
+import { Response as PlaywrightResponse } from 'playwright';
+
+let response: PlaywrightResponse;
+
+test.describe('Redirect chain', () => {
+
+    test.beforeEach(async ({ redirectChainPage }) => {
+        const res = await redirectChainPage.goto();
+        if (!res) {
+            throw new Error('No se pudo navegar a /apps/redirect');
+        }
+        response = res;
+    });
+
+    test('Should display correct page pages after redirecting', async ({ redirectChainPage }) => {
+
+        const redirectChain: string[] = [];
+
+        // Listen for the response event to capture the redirect chain.
+        // Use this instead of 'redirectedFrom()' (https://playwright.dev/docs/api/class-request#request-redirected-from) 
+        redirectChainPage.page.on('response', async (response) => {
+            if (response.url().includes('/apps/redirect/') && response.url().includes('.html')) {
+                redirectChain.push(response.url());
+            }
+        });
+
+        await redirectChainPage.clickButtonStartRedirection();
+
+        await redirectChainPage.page.waitForURL('**/apps/redirect/last', { timeout: 10000 });
+
+        expect(await redirectChainPage.getTitle()).toContain('Last Page');
+        expect(await redirectChainPage.getUrl()).toContain("/apps/redirect/last");
+        expect(await redirectChainPage.getInfoOfPage()).toContain("Welcome to the Last Page");
+        expect(redirectChain.length).toBe(6);
+        expect(redirectChain[0]).toContain("/apps/redirect/second");
+        expect(redirectChain[1]).toContain("/apps/redirect/third");
+        expect(redirectChain[2]).toContain("/apps/redirect/fourth");
+        expect(redirectChain[3]).toContain("/apps/redirect/fifth");
+        expect(redirectChain[4]).toContain("/apps/redirect/sixth");
+        expect(redirectChain[5]).toContain("/apps/redirect/last");
+    });
+});

--- a/tests/playground/ui/redirect-chain.spec.ts
+++ b/tests/playground/ui/redirect-chain.spec.ts
@@ -8,25 +8,27 @@ test.describe('Redirect chain', () => {
     test.beforeEach(async ({ redirectChainPage }) => {
         const res = await redirectChainPage.goto();
         if (!res) {
-            throw new Error('No se pudo navegar a /apps/redirect');
+            throw new Error('Error navigating to URL app (/apps/redirect)');
         }
         response = res;
     });
 
-    test('Should display correct page pages after redirecting', async ({ redirectChainPage }) => {
+    test('Should display correct pages after redirecting', async ({ redirectChainPage }) => {
 
         const redirectChain: string[] = [];
 
-        // Listen for the response event to capture the redirect chain.
-        // Use this instead of 'redirectedFrom()' (https://playwright.dev/docs/api/class-request#request-redirected-from) 
+        // Add listen the responses event to capture the redirect chain.
+        // Used this instead of 'redirectedFrom()' (https://playwright.dev/docs/api/class-request#request-redirected-from) 
         redirectChainPage.page.on('response', async (response) => {
-            if (response.url().includes('/apps/redirect/') && response.url().includes('.html')) {
+            // Check if the response URL matches the redirect pattern '/apps/redirect/*.html'.
+            if (/\/apps\/redirect\/.*\.html/.test(response.url())) {
                 redirectChain.push(response.url());
             }
         });
 
         await redirectChainPage.clickButtonStartRedirection();
 
+        // It waits up to 10 seconds for the last page to load.
         await redirectChainPage.page.waitForURL('**/apps/redirect/last', { timeout: 10000 });
 
         expect(await redirectChainPage.getTitle()).toContain('Last Page');

--- a/tests/playground/ui/redirect-chain.spec.ts
+++ b/tests/playground/ui/redirect-chain.spec.ts
@@ -42,4 +42,9 @@ test.describe('Redirect chain', () => {
         expect(redirectChain[4]).toContain("/apps/redirect/sixth");
         expect(redirectChain[5]).toContain("/apps/redirect/last");
     });
+
+    test.afterEach(async ({ redirectChainPage }) => {
+        // Remove the listener to avoid memory leaks.
+        redirectChainPage.page.removeAllListeners('response');
+    });
 });


### PR DESCRIPTION
Resolve #20 

I added a listener to the responses event to capture the redirect chain, instead of '[redirectedFrom()](https://playwright.dev/docs/api/class-request#request-redirected-from)', because this method only show initial URL

![image](https://github.com/user-attachments/assets/8da15c4e-2f50-4ad1-b91b-d844680dd258)       